### PR TITLE
Use `keys` and `values` rather than `iter().map(...)`

### DIFF
--- a/src/mimic/src/ic/structures/btreemap.rs
+++ b/src/mimic/src/ic/structures/btreemap.rs
@@ -30,12 +30,12 @@ where
 
     /// keys
     pub fn keys(&self) -> impl Iterator<Item = K> + '_ {
-        self.data.iter().map(|(k, _)| k)
+        self.data.keys()
     }
 
     /// values
     pub fn values(&self) -> impl Iterator<Item = V> + '_ {
-        self.data.iter().map(|(_, v)| v)
+        self.data.values()
     }
 
     /// clear


### PR DESCRIPTION
I implemented `keys` and `values` within `ic-stable-structures` and saw you were using `iter().map(...)`.

Using `keys` and `values` is more efficient because it only deserializes the field you are asking for.